### PR TITLE
Use key press/release for movement

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -3,5 +3,4 @@
 (defpackage #:mds
   (:use :cl :alexandria :trivial-gamekit)
   (:shadowing-import-from :trivial-gamekit :lerp)
-
-)
+  (:export #:run))


### PR DESCRIPTION
You don't need to merge this pull request (but feel free to if you wish under whatever license you like) - it just shows how to work around crappy `:repeating`  behavior.

Also I've put engine start routine into `#'run`. Starting a game upon loading will bite you later when you try to build an executable for distribution. Dev cycle would be like: invoke `#'run`, write stuff, if game restart required - `(gamekit:stop) (mds:run)` will restart it